### PR TITLE
Fix background music path

### DIFF
--- a/src/components/game/audioManager.ts
+++ b/src/components/game/audioManager.ts
@@ -100,7 +100,8 @@ class AudioManager {
 
     const promise = new Promise<void>((resolve) => {
       const audio = new Audio();
-      const musicPath = `/audio/music/${level}.ogg`;
+      // Use BASE_URL so paths work both in dev and in production subfolders
+      const musicPath = `${import.meta.env.BASE_URL}audio/music/${level}.ogg`;
       
       audio.preload = 'auto';
       audio.loop = true;
@@ -127,6 +128,8 @@ class AudioManager {
       audio.addEventListener('canplaythrough', onLoad);
       audio.addEventListener('error', onError);
       audio.src = musicPath;
+      // Ensure the file actually begins loading
+      audio.load();
     });
 
     this.musicPreloadPromises.set(level, promise);


### PR DESCRIPTION
## Summary
- ensure music files load with correct `BASE_URL`
- trigger `load()` so `<audio>` starts fetching immediately

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6853d907d078832c83753b622786e524