### PR TITLE
Fix pause timing and HUD counters

### DIFF
--- a/src/components/game/GameEngine.ts
+++ b/src/components/game/GameEngine.ts
@@ -773,6 +773,8 @@ export class GameEngine {
 
   public start() {
     console.log('Starting game engine...');
+    // Reset timestamp to avoid huge delta after pause
+    this.lastUpdateTimestamp = Date.now();
     this.gameLoop();
   }
 

--- a/src/components/game/bonuses.ts
+++ b/src/components/game/bonuses.ts
@@ -47,7 +47,7 @@ export function handleBonuses({
       heal(player, 20); // Восстанавливаем 20 HP
       pizzas.splice(i, 1);
       audioManager.playHealthSound();
-      callbacks.onStateUpdate();
+      callbacks.onStateUpdate({ health: player.health });
     }
   }
 
@@ -75,7 +75,7 @@ export function handleBonuses({
       brasilenas.splice(i, 1);
       if (freeBrasilena) freeBrasilena.onPickup();
       audioManager.playAmmoSound();
-      callbacks.onStateUpdate();
+      callbacks.onStateUpdate({ ammo: player.ammo });
     }
   }
 
@@ -92,7 +92,7 @@ export function handleBonuses({
       wineCollectedTotal += 1;
       lastWineSpawnTime = now;
       audioManager.playPowerupSound();
-      callbacks.onStateUpdate();
+      callbacks.onStateUpdate({});
     }
   }
 

--- a/src/components/game/bullets.ts
+++ b/src/components/game/bullets.ts
@@ -95,8 +95,8 @@ export function updateBullets({ bullets, enemies, swordfish, bossLucia, player, 
           
           // Звук получения монет
           audioManager.playCoinSound();
-          
-          callbacks.onStateUpdate();
+
+          callbacks.onStateUpdate({ coins: player.coins });
           break;
         }
       }
@@ -123,8 +123,8 @@ export function updateBullets({ bullets, enemies, swordfish, bossLucia, player, 
             
             // Звук получения монет
             audioManager.playCoinSound();
-            
-            callbacks.onStateUpdate();
+
+            callbacks.onStateUpdate({ coins: player.coins });
             break;
           }
         }

--- a/src/components/game/player.ts
+++ b/src/components/game/player.ts
@@ -86,7 +86,7 @@ export function updatePlayer({ player, platforms, coins, pizzas, brasilenas, win
       coins.splice(i, 1);
       addCoin(player, 1);
       audioManager.playCoinSound();
-      callbacks.onStateUpdate();
+      callbacks.onStateUpdate({ coins: player.coins });
     }
   }
 
@@ -109,7 +109,7 @@ export function updatePlayer({ player, platforms, coins, pizzas, brasilenas, win
       onCollect: () => {
         player.ammo += 20;
         audioManager.playAmmoSound();
-        callbacks.onStateUpdate();
+        callbacks.onStateUpdate({ ammo: player.ammo });
       }
     });
   }


### PR DESCRIPTION
## Summary
- reset engine timestamp when resuming to avoid long delta times
- send updated values to HUD when coins or ammo change
- update callbacks for health and ammo pickups

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_6853df7cd904832ca238b361bb6c6f24