### PR TITLE
Fix mobile jump control

### DIFF
--- a/src/components/game/player.ts
+++ b/src/components/game/player.ts
@@ -10,7 +10,12 @@ export function updatePlayer({ player, platforms, coins, pizzas, brasilenas, win
   // Обработка мобильных контролов
   const leftPressed = keys.ArrowLeft || keys.KeyA || mobileControlState.left;
   const rightPressed = keys.ArrowRight || keys.KeyD || mobileControlState.right;
-  const upPressed = keys.ArrowUp || keys.KeyW || keys.Space || mobileControlState.up;
+  const upPressed =
+    keys.ArrowUp ||
+    keys.KeyW ||
+    keys.Space ||
+    mobileControlState.up ||
+    mobileControlState.jump;
 
   // Горизонтальное движение
   if (leftPressed) {


### PR DESCRIPTION
## Summary
- ensure the mobile jump button maps to `up` control state
- update packages for test run

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685404e29534832c9542b4733c4226f1