### PR TITLE
Fix parallax rendering order

### DIFF
--- a/src/components/game/renderer.ts
+++ b/src/components/game/renderer.ts
@@ -30,6 +30,9 @@ export function renderScene(
   ctx.fillStyle = gradient;
   ctx.fillRect(0, 0, canvas.width, canvas.height);
 
+  // Draw scrolling parallax background on top of the gradient
+  engine.background?.draw(ctx);
+
   // --- Пузыри ---
   engine.updateBubbles?.();
   engine.drawBubbles?.(ctx);


### PR DESCRIPTION
## Summary
- draw parallax background above the gradient so layers stay visible

## Testing
- `npm run lint`
- `npm run dev` *(server started)*

------
https://chatgpt.com/codex/tasks/task_e_68541b0c9a50832cb64d2158a0719518