### PR TITLE
Introduce godmode helpers

### DIFF
--- a/src/components/PlayerRegistrationForm.tsx
+++ b/src/components/PlayerRegistrationForm.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from '@/hooks/useTranslations';
 import type { PlayerData } from '@/contexts/GameContext';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
+import { isGodmodeUser } from '@/constants';
 
 const SPECIAL_LOGIN = '@Molamola_9@';
 
@@ -15,7 +16,7 @@ const PlayerRegistrationForm = () => {
   const [email, setEmail] = useState('');
   const [submitError, setSubmitError] = useState('');
 
-  const godmode = nickname.trim() === '@MolaMolaCoin';
+  const godmode = isGodmodeUser(nickname.trim());
   // Новый спец-режим (Molamola Mark)
   const isMark = nickname.trim() === SPECIAL_LOGIN;
 

--- a/src/components/game/GameEngine.ts
+++ b/src/components/game/GameEngine.ts
@@ -1,5 +1,6 @@
 import { GameState } from './types';
-import { isGodmodeActive, applyGodmodeIfNeeded } from './godmode';
+import { applyGodmodeIfNeeded } from './godmode';
+import { isGodmodeUser } from '@/constants';
 import { handleEnemyCollisions, handleSwordfishCollisions } from './collisionHandlers';
 import { useFreeBrasilena } from './useFreeBrasilena';
 
@@ -209,7 +210,7 @@ export class GameEngine {
     this.player.jumpPower = -15;
 
     // ВАЖНО: Применяем godmode ПОСЛЕ установки всех параметров
-    if (this.player.godmode || this.player.username === '@MolaMolaCoin') {
+    if (isGodmodeUser(this.player.username, this.player.godmode)) {
       console.log("[GameEngine] GODMODE ACTIVATED for user:", this.player.username, "godmode flag:", this.player.godmode);
       this.player.health = 100;
       applyGodmodeIfNeeded(this.player, this.player.godmode);
@@ -602,7 +603,7 @@ export class GameEngine {
   private updateGameState() {
     // --- score удаляем полностью
     // Применяем godmode если активен
-    if (isGodmodeActive(this.player.godmode) || this.player.username === '@MolaMolaCoin') {
+    if (isGodmodeUser(this.player.username, this.player.godmode)) {
       this.player.health = 100;
     }
     this.callbacks.onStateUpdate({

--- a/src/components/game/collisionHandlers.ts
+++ b/src/components/game/collisionHandlers.ts
@@ -2,6 +2,7 @@
 import { isGodmodeActive, applyGodmodeIfNeeded } from './godmode';
 import { takeDamage, Player } from './playerEffects'; // используем Player из playerEffects
 import { audioManager } from './audioManager';
+import { isGodmodeUser } from '@/constants';
 
 type Enemy = {
   x: number;
@@ -46,16 +47,16 @@ export function handleEnemyCollisions(
       collided = true;
       
       // Проверяем godmode двумя способами: через флаг godmode ИЛИ через username
-      const isGodmodeUser = player?.username === '@MolaMolaCoin' || isGodmodeActive(godmode) || player.godmode;
+      const godmodeUser = isGodmodeUser(player?.username, godmode || player.godmode);
       
       console.log('[collisionHandlers] Collision detected:', {
         username: player?.username,
         godmode: godmode,
         playerGodmode: player.godmode,
-        isGodmodeUser: isGodmodeUser
+        isGodmodeUser: godmodeUser
       });
       
-      if (isGodmodeUser) {
+      if (godmodeUser) {
         // Принудительно устанавливаем здоровье в 100 для godmode пользователей
         player.health = 100;
         console.log('[collisionHandlers] Godmode active - health set to 100');
@@ -109,16 +110,16 @@ export function handleSwordfishCollisions(
       collided = true;
       
       // Проверяем godmode двумя способами: через флаг godmode ИЛИ через username
-      const isGodmodeUser = player?.username === '@MolaMolaCoin' || isGodmodeActive(godmode) || player.godmode;
+      const godmodeUser = isGodmodeUser(player?.username, godmode || player.godmode);
       
       console.log('[collisionHandlers] Swordfish collision detected:', {
         username: player?.username,
         godmode: godmode,
         playerGodmode: player.godmode,
-        isGodmodeUser: isGodmodeUser
+        isGodmodeUser: godmodeUser
       });
       
-      if (isGodmodeUser) {
+      if (godmodeUser) {
         // Принудительно устанавливаем здоровье в 100 для godmode пользователей
         player.health = 100;
         console.log('[collisionHandlers] Godmode active - health set to 100');

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,5 @@
+export const GODMODE_USERNAME = '@MolaMolaCoin';
+
+export function isGodmodeUser(username?: string, flag?: boolean): boolean {
+  return Boolean(flag) || username === GODMODE_USERNAME;
+}

--- a/tests/godmode.test.ts
+++ b/tests/godmode.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { isGodmodeUser } from '../src/constants';
+
+describe('isGodmodeUser', () => {
+  it('returns true for the special username', () => {
+    expect(isGodmodeUser('@MolaMolaCoin')).toBe(true);
+  });
+
+  it('returns true when godmode flag is true', () => {
+    expect(isGodmodeUser('anything', true)).toBe(true);
+  });
+
+  it('returns false for normal users without flag', () => {
+    expect(isGodmodeUser('player')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- centralize godmode username and helper in `constants.ts`
- use `isGodmodeUser` in registration form
- use `isGodmodeUser` when checking collisions
- use `isGodmodeUser` inside game engine updates
- test `isGodmodeUser` helper

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_685482ac5814832c88a03a08e732d04c