### PR TITLE
Fix godmode username checks and trim nickname

### DIFF
--- a/src/components/PlayerRegistrationForm.tsx
+++ b/src/components/PlayerRegistrationForm.tsx
@@ -57,7 +57,7 @@ const PlayerRegistrationForm = () => {
       return;
     }
     const data: PlayerData = {
-      nickname,
+      nickname: nickname.trim(),
       email: godmode ? '-' : email,
       language,
       godmode,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,8 @@
 export const GODMODE_USERNAME = '@MolaMolaCoin';
 
 export function isGodmodeUser(username?: string, flag?: boolean): boolean {
-  return Boolean(flag) || username === GODMODE_USERNAME;
+  return (
+    Boolean(flag) ||
+    username?.trim().toLowerCase() === GODMODE_USERNAME.toLowerCase()
+  );
 }

--- a/tests/godmode.test.ts
+++ b/tests/godmode.test.ts
@@ -13,4 +13,12 @@ describe('isGodmodeUser', () => {
   it('returns false for normal users without flag', () => {
     expect(isGodmodeUser('player')).toBe(false);
   });
+
+  it('is case insensitive', () => {
+    expect(isGodmodeUser('@molamolacoin')).toBe(true);
+  });
+
+  it('ignores leading and trailing spaces', () => {
+    expect(isGodmodeUser('  @MolaMolaCoin  ')).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- fix `isGodmodeUser` to trim and normalize usernames
- trim nickname when storing `PlayerData`
- extend tests for case and whitespace handling

## Testing
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6855014ca81c832ca4d45f5643dd9ea5