### PR TITLE
Ensure godmode nickname trim/lowercase

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,8 +1,8 @@
 export const GODMODE_USERNAME = '@MolaMolaCoin';
 
+const GODMODE_USERNAME_NORMALIZED = GODMODE_USERNAME.trim().toLowerCase();
+
 export function isGodmodeUser(username?: string, flag?: boolean): boolean {
-  return (
-    Boolean(flag) ||
-    username?.trim().toLowerCase() === GODMODE_USERNAME.toLowerCase()
-  );
+  const normalized = username?.trim().toLowerCase();
+  return Boolean(flag) || normalized === GODMODE_USERNAME_NORMALIZED;
 }

--- a/tests/godmode.test.ts
+++ b/tests/godmode.test.ts
@@ -1,5 +1,15 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { isGodmodeUser } from '../src/constants';
+import { applyGodmodeIfNeeded } from '../src/components/game/godmode';
+
+vi.mock('../src/components/game/audioManager', () => ({
+  audioManager: {
+    playDamageSound: vi.fn(),
+    playGameOverSound: vi.fn(),
+  },
+}));
+
+import { handleEnemyCollisions } from '../src/components/game/collisionHandlers';
 
 describe('isGodmodeUser', () => {
   it('returns true for the special username', () => {
@@ -20,5 +30,27 @@ describe('isGodmodeUser', () => {
 
   it('ignores leading and trailing spaces', () => {
     expect(isGodmodeUser('  @MolaMolaCoin  ')).toBe(true);
+  });
+
+  it('handles spaces and case together', () => {
+    expect(isGodmodeUser('  @molamolacoin  ')).toBe(true);
+  });
+});
+
+describe('godmode integration', () => {
+  it('forces full health on initialization for special user', () => {
+    const player = { health: 50 };
+    applyGodmodeIfNeeded(player, isGodmodeUser(' @molamolacoin '));
+    expect(player.health).toBe(100);
+  });
+
+  it('prevents damage when collided', () => {
+    const player: any = { health: 100, username: ' @molamolacoin ', level: 1, coins: 0 };
+    const enemy = { x: 0, y: 0, width: 10, height: 10 };
+    const checkCollision = () => true;
+    const callbacks = { onGameEnd: vi.fn(), onStateUpdate: vi.fn() };
+    handleEnemyCollisions(player, [enemy], false, checkCollision, callbacks);
+    expect(player.health).toBe(100);
+    expect(callbacks.onGameEnd).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- normalize the godmode username
- mock audioManager for collision tests
- cover more cases for `@MolaMolaCoin` nickname

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_685504e8ca70832cb017926330e5fb82