### PR TITLE
Fix mobile jump control

### DIFF
--- a/src/components/game/player.ts
+++ b/src/components/game/player.ts
@@ -13,8 +13,9 @@ export function updatePlayer({ player, platforms, coins, pizzas, brasilenas, win
   const upPressed =
     keys.ArrowUp ||
     keys.KeyW ||
-    mobileControlState.up ||
-    mobileControlState.jump;
+    keys.Space ||
+    mobileControlState.jump ||
+    mobileControlState.up;
 
   // Горизонтальное движение
   if (leftPressed) {


### PR DESCRIPTION
## Summary
- allow spacebar to trigger jump action along with mobile control states

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68552df74768832ca3949f1a4c4a1f85