### PR TITLE
Fix level transition timers

### DIFF
--- a/src/components/game/GameEngine.ts
+++ b/src/components/game/GameEngine.ts
@@ -422,6 +422,12 @@ export class GameEngine {
     this.brasilenas = [];
     this.wines = [];
 
+    // Сброс таймеров появления ресурсов и платформ при старте уровня
+    const now = Date.now();
+    this.lastResourceSpawnTime = now;
+    this.lastPlatformSpawnTime = now;
+    this.lastUpdateTimestamp = now;
+
     const config = getLevelConfig(this.player.level);
 
     // --- Запускаем музыку для этого уровня ---


### PR DESCRIPTION
## Summary
- reset timer variables when generating a new level

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685541852a44832ca4cd40962bd2b335