### PR TITLE
Fix blog link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,4 +127,4 @@ Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-trick
 
 6. Сборка, настройка и публикация — стандартные для App Store приложения шаги.
 
-Полное руководство — [Блог Lovable: публикация мобильных приложений](https://lovable.dev/blogs/TODO)
+Полное руководство — [Блог Lovable: публикация мобильных приложений](https://lovable.dev/blogs/)


### PR DESCRIPTION
## Summary
- replace TODO blog link with root blog location

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68554fafd4fc832cbc410865be4b8a89