### PR TITLE
Enhance mobile jump control and log init

### DIFF
--- a/src/components/game/GameCanvas.tsx
+++ b/src/components/game/GameCanvas.tsx
@@ -59,7 +59,9 @@ const GameCanvas: React.FC<GameCanvasProps> = ({
           engineRef.current = engine;
           collectEngineRef?.(engine);
           setLoading(true);
+          console.log('[GameCanvas] Waiting for engine initialization...');
           await engine.init();
+          console.log('GameEngine и все ассеты загружены!');
           if (cancelled) return;
           setLoading(false);
           if (!isPaused) engine.start();

--- a/src/components/game/MobileControls.tsx
+++ b/src/components/game/MobileControls.tsx
@@ -44,12 +44,14 @@ export default function MobileControls({ onControl }: MobileControlsProps) {
       {/* Правая панель */}
       <div className="flex gap-2">
         {/* Прыжок */}
-        <button 
+        <button
           className="rounded-full bg-black/80 text-yellow-200 w-14 h-14 text-3xl flex items-center justify-center border-2 border-yellow-400 active:bg-cyan-800 transition duration-75"
           style={{ touchAction: "none" }}
           tabIndex={-1}
           onTouchStart={e => { e.preventDefault(); onControl("jump", true); }}
           onTouchEnd={e => { e.preventDefault(); onControl("jump", false); }}
+          onPointerDown={() => onControl("jump", true)}
+          onPointerUp={() => onControl("jump", false)}
           onMouseDown={() => onControl("jump", true)}
           onMouseUp={() => onControl("jump", false)}
         >


### PR DESCRIPTION
## Summary
- support pointer events for the jump button in `MobileControls`
- log message after awaiting `engine.init`
- cache images and log load failures

## Testing
- `npx vitest run` *(fails: missing vite package)*

------
https://chatgpt.com/codex/tasks/task_e_68578bbfca08832ca521b0c0d7cd14d6