### PR TITLE
Add dependency reminder before tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,11 @@ the `prelint` script defined in `package.json`.
 
 ## Running tests
 
-To run the test suite, make sure the project dependencies are installed:
+To run the test suite, first install the project dependencies with `npm install`
+or `pnpm install`:
 
 ```sh
-npm install
+npm install # or pnpm install
 npm test
 ```
 This will execute the Vitest suite.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "prelint": "npm install",
     "lint": "eslint .",
     "preview": "vite preview",
+    "pretest": "node -e 'const fs=require(\"fs\"); if (!fs.existsSync(\"node_modules\")) { console.error(\"Dependencies not installed. Run npm install or pnpm install before testing.\"); process.exit(1); }'",
     "test": "vitest"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- mention `npm install` or `pnpm install` before running tests
- add a `pretest` script that warns if dependencies are missing

## Testing
- `npm test` *(fails: waiting for file changes)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68565ef7c908832cb2eca730034993b7