### PR TITLE
Add swordfish animation

### DIFF
--- a/src/components/game/GameEngine.ts
+++ b/src/components/game/GameEngine.ts
@@ -93,6 +93,9 @@ export class GameEngine {
     width: number;
     height: number;
     direction: number;
+    frame: number;
+    frameTimer: number;
+    frameRate: number;
     _wavePhase?: number;
   }> = [];
 
@@ -499,6 +502,9 @@ const config = getLevelConfig(this.player.level);
           width: 64,
           height: 48,
           direction: Math.random() > 0.5 ? 1 : -1,
+          frame: 0,
+          frameTimer: 0,
+          frameRate: 12,
         });
       }
     }

--- a/src/components/game/enemies.ts
+++ b/src/components/game/enemies.ts
@@ -44,6 +44,16 @@ export function updateEnemies({ bossLucia, enemies, swordfish, player, canvas, c
 
   // Обновление Swordfish - горизонтальное движение по середине экрана
   swordfish.forEach(sword => {
+    // Пропускаем обновление, если рыба вне экрана
+    if (
+      sword.x + sword.width < 0 ||
+      sword.x > canvas.width ||
+      sword.y + sword.height < 0 ||
+      sword.y > canvas.height
+    ) {
+      return;
+    }
+
     // Инициализация направления движения если не задано
     if (!sword.direction) {
       sword.direction = Math.random() > 0.5 ? 1 : -1;
@@ -65,6 +75,13 @@ export function updateEnemies({ bossLucia, enemies, swordfish, player, canvas, c
     if (!sword._wavePhase) sword._wavePhase = Math.random() * Math.PI * 2;
     sword._wavePhase += 0.05;
     sword.y += Math.sin(sword._wavePhase) * 0.5;
+
+    // Анимация
+    sword.frameTimer += 1;
+    if (sword.frameTimer >= sword.frameRate) {
+      sword.frameTimer = 0;
+      sword.frame = (sword.frame + 1) % 2;
+    }
 
     // Ограничиваем вертикальное движение
     const minY = canvas.height * 0.3;

--- a/src/components/game/renderer.ts
+++ b/src/components/game/renderer.ts
@@ -180,7 +180,18 @@ export function renderScene(
     }
 
     if (isImageLoaded(image)) {
-      ctx.drawImage(image, sword.x, sword.y, sword.width, sword.height);
+      const frameWidth = image.width / 2;
+      ctx.drawImage(
+        image,
+        sword.frame * frameWidth,
+        0,
+        frameWidth,
+        image.height,
+        sword.x,
+        sword.y,
+        sword.width,
+        sword.height
+      );
     } else {
       // Логирование только в dev-режиме
       if (process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
## Summary
- animate swordfish sprites
- only update swordfish when they're on screen
- draw swordfish from sprite sheet

## Testing
- `npm test` *(fails: Dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685878187bc4832ca1c9e1383f4300df