### PR TITLE
Fix swordfish animation timer

### DIFF
--- a/src/components/game/enemies.ts
+++ b/src/components/game/enemies.ts
@@ -77,7 +77,7 @@ export function updateEnemies({ bossLucia, enemies, swordfish, player, canvas, c
     sword.y += Math.sin(sword._wavePhase) * 0.5;
 
     // Анимация
-    sword.frameTimer += 1;
+    sword.frameTimer = (sword.frameTimer ?? 0) + 1;
     if (sword.frameTimer >= sword.frameRate) {
       sword.frameTimer = 0;
       sword.frame = (sword.frame + 1) % 2;


### PR DESCRIPTION
## Summary
- safeguard swordfish frame timer initialization

## Testing
- `npm test` *(fails: Dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68587f53bbac832ca9d0474b34463e18