### PR TITLE
Add wave offset for swordfish spawning

### DIFF
--- a/src/components/game/GameEngine.ts
+++ b/src/components/game/GameEngine.ts
@@ -505,6 +505,7 @@ const config = getLevelConfig(this.player.level);
           frame: 0,
           frameTimer: 0,
           frameRate: 12,
+          _wavePhase: Math.random() * Math.PI * 2,
         });
       }
     }


### PR DESCRIPTION
## Summary
- add immediate `_wavePhase` initialization when creating swordfish

## Testing
- `npm test` *(fails: Dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6858860e1914832cb93c43fd0e48b19d