### PR TITLE
Remove redundant GameProvider wrapper

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import LandingPage from '@/components/LandingPage';
 import { useNavigate } from 'react-router-dom';
-import { GameProvider } from '@/contexts/GameContext';
+// GameProvider is now applied globally in App.tsx
 // Не импортируем Button больше здесь
 import MobileGuidesNav from "@/components/MobileGuidesNav";
 
@@ -14,13 +14,11 @@ const Index = () => {
   };
 
   return (
-    <GameProvider>
-      <div className="flex flex-col space-y-3 w-full max-w-xl mx-auto">
-        {/* Для показа кнопок мобильных гайдов раскомментируйте строку ниже */}
-        {/* <MobileGuidesNav /> */}
-        <LandingPage onPlay={handlePlay} />
-      </div>
-    </GameProvider>
+    <div className="flex flex-col space-y-3 w-full max-w-xl mx-auto">
+      {/* Для показа кнопок мобильных гайдов раскомментируйте строку ниже */}
+      {/* <MobileGuidesNav /> */}
+      <LandingPage onPlay={handlePlay} />
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
- drop `GameProvider` from the index page so it relies on the provider in `App.tsx`

## Testing
- `npm test` *(fails: Dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6859032b7754832c9fc2694489900fe9