### PR TITLE
Add error handling to Game component

### DIFF
--- a/src/pages/Game.tsx
+++ b/src/pages/Game.tsx
@@ -1,5 +1,5 @@
 
-import React from "react";
+import React, { useEffect, useState } from "react";
 import MolaMolaGame from '@/components/game/MolaMolaGame';
 import { useLocation } from 'react-router-dom';
 
@@ -15,23 +15,40 @@ const Game = () => {
   const params = new URLSearchParams(location.search);
   const autoStart = params.get('autostart') === '1';
 
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    console.log('[Game] Mounted');
+  }, []);
+
   // Класс для Telegram UI-правок
   const telegramClass = isTelegramBrowser() ? "tg-browser" : "";
 
   // Заблокируем прокрутку только на странице игры, но разрешим масштабирование
   const containerClass = `no-scroll fixed inset-0 z-0 bg-gradient-to-b from-blue-900 to-blue-700 flex items-center justify-center p-0 ${telegramClass}`;
 
-  return (
-    <div
-      className={containerClass}
-      style={{
-        touchAction: 'pinch-zoom', // Разрешаем масштабирование двумя пальцами
-        WebkitOverflowScrolling: "auto",
-      }}
-    >
-      <MolaMolaGame autoStart={autoStart} />
-    </div>
-  );
+  try {
+    return (
+      <div
+        className={containerClass}
+        style={{
+          touchAction: 'pinch-zoom', // Разрешаем масштабирование двумя пальцами
+          WebkitOverflowScrolling: "auto",
+        }}
+      >
+        <MolaMolaGame autoStart={autoStart} />
+      </div>
+    );
+  } catch (err) {
+    console.error('[Game] Render error:', err);
+    setError(err instanceof Error ? err : new Error(String(err)));
+  }
+
+  if (error) {
+    return <div style={{ color: 'red' }}>❌ Failed to load game: {error.message}</div>;
+  }
+
+  return null;
 };
 
 export default Game;


### PR DESCRIPTION
## Summary
- log when `Game` mounts
- catch rendering errors in `Game`
- show fallback if the game fails to render

## Testing
- `npm test` *(fails: Dependencies not installed)*
- `npm run lint` *(fails: npm install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6859363a2664832c8047011c296395e1