### PR TITLE
Remove parallax background

### DIFF
--- a/src/components/game/GameCanvas.tsx
+++ b/src/components/game/GameCanvas.tsx
@@ -91,7 +91,7 @@ const GameCanvas: React.FC<GameCanvasProps> = ({
   return (
     <div
       ref={containerRef}
-      className="absolute inset-0 w-full h-full bg-[#011b2e] outline-none flex items-center justify-center"
+      className="absolute inset-0 w-full h-full bg-[#084e82] outline-none flex items-center justify-center"
       style={{
         touchAction: "manipulation",
         WebkitTouchCallout: "none",
@@ -110,7 +110,7 @@ const GameCanvas: React.FC<GameCanvasProps> = ({
         id="game-canvas"
         className="block outline-none"
         style={{
-          background: "#011b2e",
+          background: "#084e82",
           display: "block",
           border: "none",
           imageRendering: "pixelated",

--- a/src/components/game/MolaMolaGame.tsx
+++ b/src/components/game/MolaMolaGame.tsx
@@ -56,7 +56,7 @@ const MolaMolaGame = ({ autoStart = false }: { autoStart?: boolean }) => {
 
   return (
     <div
-      className="w-screen bg-[#011b2e] relative flex flex-col overflow-hidden"
+      className="w-screen bg-[#084e82] relative flex flex-col overflow-hidden"
       style={{
         height: '100svh',
       }}

--- a/src/components/game/renderer.ts
+++ b/src/components/game/renderer.ts
@@ -31,7 +31,7 @@ export function renderScene(
   ctx.fillRect(0, 0, canvas.width, canvas.height);
 
   // Draw scrolling parallax background on top of the gradient
-  engine.background?.draw(ctx);
+  // engine.background?.draw(ctx);
 
   // --- Пузыри ---
   engine.updateBubbles?.();


### PR DESCRIPTION
## Summary
- comment out `engine.background?.draw` call
- use a simple teal background color for game container

## Testing
- `npm test` *(fails: Dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68593ba9e058832cb52f9d045a801b84