### PR TITLE
Add skeleton mode image placeholders

### DIFF
--- a/src/components/FeatureList.tsx
+++ b/src/components/FeatureList.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { IS_SKELETON_MODE } from "@/constants";
 
 // Путь к изображению монеты
 // оригинальный webp отсутствует, используем png-версию
@@ -13,6 +14,7 @@ interface Feature {
 const ICON_SIZE = 22;
 
 export default function FeatureList({ features }: { features: Feature[] }) {
+  const skeleton = IS_SKELETON_MODE;
   const iconMap: Record<string, React.ReactNode> = {
     pixel: (
       <span
@@ -47,18 +49,31 @@ export default function FeatureList({ features }: { features: Feature[] }) {
         className="inline-block align-middle mr-2"
         style={{ width: ICON_SIZE, minWidth: ICON_SIZE, textAlign: "center" }}
       >
-        <img
-          src={MOLA_COIN_IMG}
-          alt="Mola Mola Coin"
-          style={{
-            width: ICON_SIZE,
-            height: ICON_SIZE,
-            display: "inline-block",
-            objectFit: "contain",
-            verticalAlign: "middle"
-          }}
-          className="align-middle"
-        />
+        {skeleton ? (
+          <span
+            className="inline-block align-middle"
+            style={{
+              width: ICON_SIZE,
+              height: ICON_SIZE,
+              backgroundColor: '#0f172a',
+              display: 'inline-block',
+              borderRadius: '50%'
+            }}
+          />
+        ) : (
+          <img
+            src={MOLA_COIN_IMG}
+            alt="Mola Mola Coin"
+            style={{
+              width: ICON_SIZE,
+              height: ICON_SIZE,
+              display: 'inline-block',
+              objectFit: 'contain',
+              verticalAlign: 'middle'
+            }}
+            className="align-middle"
+          />
+        )}
       </span>
     ),
     powerup: (

--- a/src/components/GuidoShrimpBlock.tsx
+++ b/src/components/GuidoShrimpBlock.tsx
@@ -1,5 +1,6 @@
 
 import React from "react";
+import { IS_SKELETON_MODE } from "@/constants";
 
 const GUIDO_MESSAGES = {
   en: "Guido Shrimp greets you!",
@@ -8,6 +9,7 @@ const GUIDO_MESSAGES = {
 };
 
 export default function GuidoShrimpBlock({ language }: { language: string }) {
+  const skeleton = IS_SKELETON_MODE;
   return (
     <div className="w-full flex justify-center my-3">
       <div
@@ -26,14 +28,21 @@ export default function GuidoShrimpBlock({ language }: { language: string }) {
           paddingRight: 20,
         }}
       >
-        <img
-          // оригинальное webp изображение отсутствует
-          src="/uploads/9132b9d8-ab25-44a7-81ec-031ebfbb97e6.png"
-          alt="Guido Shrimp"
-          className="w-12 h-12 md:w-14 md:h-14 rounded-full object-cover border-2 border-yellow-300 bg-black"
-          style={{ flexShrink: 0, aspectRatio: "1/1", objectFit: "cover" }}
-          loading="lazy"
-        />
+        {skeleton ? (
+          <div
+            className="w-12 h-12 md:w-14 md:h-14 rounded-full bg-cyan-800 border-2 border-yellow-300"
+            style={{ flexShrink: 0 }}
+          />
+        ) : (
+          <img
+            // оригинальное webp изображение отсутствует
+            src="/uploads/9132b9d8-ab25-44a7-81ec-031ebfbb97e6.png"
+            alt="Guido Shrimp"
+            className="w-12 h-12 md:w-14 md:h-14 rounded-full object-cover border-2 border-yellow-300 bg-black"
+            style={{ flexShrink: 0, aspectRatio: "1/1", objectFit: "cover" }}
+            loading="lazy"
+          />
+        )}
         <span
           className="
             text-base md:text-lg font-semibold text-yellow-200 

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -9,6 +9,7 @@ import GuidoShrimpBlock from './GuidoShrimpBlock';
 import AboutSection from './AboutSection';
 import AddressSection from './AddressSection';
 import GameTitle from './GameTitle';
+import { IS_SKELETON_MODE } from '@/constants';
 
 const LandingPage = ({
   onPlay
@@ -22,6 +23,7 @@ const LandingPage = ({
   } = useGame();
   const t = useTranslations(language);
   const [view, setView] = useState<'language' | 'register' | 'ready'>('language');
+  const skeleton = IS_SKELETON_MODE;
 
   // Переключение вида в пошаговом режиме
   const handleStart = () => {
@@ -75,11 +77,15 @@ const LandingPage = ({
           {/* Новый компонент заголовка */}
           <GameTitle />
         </div>
-        <img
-          src="/uploads/ee8156f0-ed84-469d-b314-13a6aa436d63.png"
-          alt="Mola Mola"
-          className="w-[160px] md:w-[210px] h-20 md:h-24 mb-1 mx-auto object-contain"
-        />
+        {skeleton ? (
+          <div className="w-[160px] md:w-[210px] h-20 md:h-24 mb-1 mx-auto bg-cyan-800 rounded" />
+        ) : (
+          <img
+            src="/uploads/ee8156f0-ed84-469d-b314-13a6aa436d63.png"
+            alt="Mola Mola"
+            className="w-[160px] md:w-[210px] h-20 md:h-24 mb-1 mx-auto object-contain"
+          />
+        )}
         {/* Language selector block */}
         <LanguageSelector language={language} setLanguage={setLanguage} />
         {/* Guido Shrimp block */}

--- a/src/components/PlayerRegistrationForm.tsx
+++ b/src/components/PlayerRegistrationForm.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from '@/hooks/useTranslations';
 import type { PlayerData } from '@/contexts/GameContext';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent } from '@/components/ui/dialog';
-import { isGodmodeUser } from '@/constants';
+import { isGodmodeUser, IS_SKELETON_MODE } from '@/constants';
 
 const SPECIAL_LOGIN = '@Molamola_9@';
 
@@ -15,6 +15,7 @@ const PlayerRegistrationForm = () => {
   const [nickname, setNickname] = useState('');
   const [email, setEmail] = useState('');
   const [submitError, setSubmitError] = useState('');
+  const skeleton = IS_SKELETON_MODE;
 
   const godmode = isGodmodeUser(nickname.trim());
   // Новый спец-режим (Molamola Mark)
@@ -106,7 +107,11 @@ const PlayerRegistrationForm = () => {
       )}
       <Dialog open={showMarkModal} onOpenChange={(open) => setShowMarkModal(open)}>
         <DialogContent className="flex flex-col items-center gap-6 bg-black/90 border-cyan-400">
-          <img src="/uploads/64235a5a-8a4e-4fac-83fe-14e82ff1bba0.png" alt="Molamola Mark" className="w-40 h-40 object-contain mx-auto" />
+          {skeleton ? (
+            <div className="w-40 h-40 mx-auto bg-cyan-800 rounded" />
+          ) : (
+            <img src="/uploads/64235a5a-8a4e-4fac-83fe-14e82ff1bba0.png" alt="Molamola Mark" className="w-40 h-40 object-contain mx-auto" />
+          )}
           <div className="text-2xl text-yellow-300 font-bold text-center animate-bounce mb-2">CIAO MARK!!!</div>
           <Button
             autoFocus

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -9,3 +9,5 @@ export function isGodmodeUser(username?: string, flag?: boolean): boolean {
   const normalized = username?.trim().toLowerCase();
   return Boolean(flag) || normalized === GODMODE_USERNAME_NORMALIZED;
 }
+
+export const IS_SKELETON_MODE = import.meta.env.VITE_SKELETON_MODE === 'true';


### PR DESCRIPTION
## Summary
- add `IS_SKELETON_MODE` constant
- show colored blocks instead of images when `VITE_SKELETON_MODE` is enabled

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68593bac2088832c94b3ab4c409edcaf