### PR TITLE
Restrict keyboard handling to spacebar

### DIFF
--- a/src/components/game/controlsManager.ts
+++ b/src/components/game/controlsManager.ts
@@ -1,14 +1,19 @@
 
 export function setupKeyboardHandlers(keys: any, shoot: () => void) {
+  // only SPACE is supported
   const handleKeyDown = (e: KeyboardEvent) => {
-    keys[e.code] = true;
     if (e.code === 'Space') {
-      e.preventDefault();
-      shoot();
+      keys.Space = true;
+      if (!e.repeat) {
+        e.preventDefault();
+        shoot();
+      }
     }
   };
   const handleKeyUp = (e: KeyboardEvent) => {
-    keys[e.code] = false;
+    if (e.code === 'Space') {
+      keys.Space = false;
+    }
   };
   document.addEventListener('keydown', handleKeyDown);
   document.addEventListener('keyup', handleKeyUp);

--- a/src/components/game/useMolaMolaGameCore.ts
+++ b/src/components/game/useMolaMolaGameCore.ts
@@ -78,16 +78,6 @@ export function useMolaMolaGameCore({
     if (!gameEnded) setIsPaused(false);
   }, [gameEnded, setIsPaused]);
 
-  // Клавиша паузы
-  useEffect(() => {
-    const handleKey = (e: KeyboardEvent) => {
-      if (e.code === "KeyP" && !gameEnded) {
-        setIsPaused((v: boolean) => !v);
-      }
-    };
-    window.addEventListener("keydown", handleKey);
-    return () => window.removeEventListener("keydown", handleKey);
-  }, [gameEnded, setIsPaused]);
 
   // HUD и GameOver обработчики (создаём фабрики чтобы иметь доступ к рефам/состояниям)
   const onStateUpdate = onStateUpdateFactory({ setHud, justResetGameRef });


### PR DESCRIPTION
## Summary
- only handle `Space` in the keyboard controls
- remove the pause hotkey listener

## Testing
- `npm test` *(fails: Dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68594da6bb04832cbce9b78ecf2e81a4