### PR TITLE
Add start and stop methods to game engine

### DIFF
--- a/src/components/game/GameEngine.ts
+++ b/src/components/game/GameEngine.ts
@@ -368,6 +368,23 @@ export class GameEngine {
     return audioManager.isMutedState();
   }
 
+  private tick = () => {
+    gameTick(this);
+    this.animationId = requestAnimationFrame(this.tick);
+  };
+
+  public start() {
+    if (this.animationId !== null) return;
+    this.animationId = requestAnimationFrame(this.tick);
+  }
+
+  public stop() {
+    if (this.animationId !== null) {
+      cancelAnimationFrame(this.animationId);
+      this.animationId = null;
+    }
+  }
+
   // --- Используем только bubblesManager ---
   private generateBubbles() {
     generateBubbles(this.bubbles, this.canvas);


### PR DESCRIPTION
## Summary
- implement `start()` and `stop()` in `GameEngine`
- loop using `requestAnimationFrame`

## Testing
- `npx tsc -p tsconfig.json`
- `npm test` *(fails: Dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685a5db3fcc0832c93b9fadc4cc43c75