### PR TITLE
Load and render parallax layers

### DIFF
--- a/src/components/game/GameEngine.ts
+++ b/src/components/game/GameEngine.ts
@@ -16,6 +16,7 @@ import { setupKeyboardHandlers } from './controlsManager';
 import { renderScene } from './renderer';
 import { gameTick } from './loop';
 import { loadImages } from './imageLoader';
+import { loadParallaxLayers, ParallaxLayers } from './parallaxLayers';
 
 import { spawnResourceForType, ResourceType } from './resourceSpawner';
 import { spawnDynamicPlatform, updateDynamicPlatforms } from './dynamicPlatforms';
@@ -140,6 +141,7 @@ export class GameEngine {
   private mobileControlState: Record<string, boolean> = {};
 
   private staticSandLayer: HTMLCanvasElement | null = null;
+  private parallaxLayers: ParallaxLayers | null = null;
 
   private freeBrasilena?: ReturnType<typeof useFreeBrasilena>;
 
@@ -237,7 +239,12 @@ export class GameEngine {
       swordfishLeft: new Image(),
     };
 
-    this.loadPromise = loadImages(this.images);
+    this.loadPromise = Promise.all([
+      loadImages(this.images),
+      loadParallaxLayers().then((layers) => {
+        this.parallaxLayers = layers;
+      }),
+    ]).then(() => {});
     setupKeyboardHandlers(this.keys, this.shoot.bind(this));
     this.generateLevel();
     this.platforms = createDefaultPlatforms(this.canvas.width, this.canvas.height);

--- a/src/components/game/renderer.ts
+++ b/src/components/game/renderer.ts
@@ -31,7 +31,12 @@ export function renderScene(
   ctx.fillRect(0, 0, canvas.width, canvas.height);
 
   // Draw scrolling parallax background on top of the gradient
-  // engine.background?.draw(ctx);
+  const layers = engine.parallaxLayers;
+  if (layers && isImageLoaded(layers.far)) {
+    ctx.drawImage(layers.far, 0, 0);
+    ctx.drawImage(layers.mid, 0, 0);
+    ctx.drawImage(layers.near, 0, 0);
+  }
 
   // --- Пузыри ---
   engine.updateBubbles?.();

--- a/tests/gameengine-parallax.test.ts
+++ b/tests/gameengine-parallax.test.ts
@@ -1,0 +1,31 @@
+// @vitest-environment jsdom
+import { it, expect, vi } from 'vitest';
+
+vi.mock('../src/components/game/audioManager', () => ({
+  audioManager: {
+    toggleMute: vi.fn(),
+    isMutedState: vi.fn().mockReturnValue(false),
+    playLevelMusic: vi.fn(),
+    playLevelWinSound: vi.fn(),
+    stopLevelMusic: vi.fn(),
+  },
+  activateAudio: vi.fn(),
+}));
+
+vi.mock('../src/components/game/staticSandLayer', () => ({
+  createStaticSandLayer: () => document.createElement('canvas'),
+}));
+
+import { GameEngine } from '../src/components/game/GameEngine';
+
+it('loads parallax layers during init', async () => {
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d')!;
+  const engine = new GameEngine(canvas, ctx, {
+    onGameEnd: () => {},
+    onStateUpdate: () => {},
+    initialState: {},
+  });
+  await engine.init();
+  expect((engine as any).parallaxLayers).toBeTruthy();
+});


### PR DESCRIPTION
## Summary
- load generated parallax backgrounds during engine setup
- expose loaded layers through `parallaxLayers`
- render far/mid/near parallax images before other layers
- add regression test for parallax loading

## Testing
- `npm test` *(fails: Dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685a5dc4107c832c9d04c9f3e334ff1f