### PR TITLE
Reset canvas alpha in game renderer

### DIFF
--- a/src/components/game/renderer.ts
+++ b/src/components/game/renderer.ts
@@ -12,6 +12,9 @@ export function renderScene(
   // Apply screen shake at the beginning
   engine.screenShake.applyShake(ctx);
 
+  // Ensure alpha is reset before drawing
+  ctx.globalAlpha = 1;
+
   // вынесем практически всё содержимое оригинального render из GameEngine
   const {
     canvas, player, images, platforms,
@@ -247,4 +250,7 @@ export function renderScene(
 
   // Reset screen shake at the end
   engine.screenShake.resetShake(ctx);
+
+  // Restore default alpha in case effects changed it
+  ctx.globalAlpha = 1;
 }


### PR DESCRIPTION
## Summary
- ensure `globalAlpha` is 1 before drawing the scene
- restore alpha after resetting screen shake
- audit of `ctx.save()`/`ctx.restore()` shows proper pairing

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a5dc832c4832cbb216604c780dc22