### PR TITLE
Add boss coin spawning utilities

### DIFF
--- a/src/components/game/GameEngine.ts
+++ b/src/components/game/GameEngine.ts
@@ -179,6 +179,37 @@ export class GameEngine {
   private generateLevel() {}
   private updateGameState() {}
 
+  // --- New: spawn coins near the boss ---
+  public spawnBossCoins(count: number = 20) {
+    const boss = this.bossLucia;
+    if (!boss) return;
+    for (let i = 0; i < count; i++) {
+      const offsetX = (Math.random() - 0.5) * boss.width;
+      const offsetY = (Math.random() - 0.5) * boss.height;
+      this.coins.push({
+        x: boss.x + boss.width / 2 + offsetX,
+        y: boss.y + boss.height / 2 + offsetY,
+        width: 32,
+        height: 32,
+        _bossCoin: true,
+      });
+    }
+  }
+
+  public spawnBossCoinsOnHit(count: number, boss: { x: number; y: number; width: number; height: number }) {
+    for (let i = 0; i < count; i++) {
+      const offsetX = (Math.random() - 0.5) * boss.width;
+      const offsetY = (Math.random() - 0.5) * boss.height;
+      this.coins.push({
+        x: boss.x + boss.width / 2 + offsetX,
+        y: boss.y + boss.height / 2 + offsetY,
+        width: 32,
+        height: 32,
+        _bossCoin: true,
+      });
+    }
+  }
+
   constructor(
     canvas: HTMLCanvasElement,
     ctx: CanvasRenderingContext2D,

--- a/tests/boss-coins.test.ts
+++ b/tests/boss-coins.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../src/components/game/audioManager', () => ({
+  audioManager: {
+    toggleMute: vi.fn(),
+    isMutedState: vi.fn().mockReturnValue(false),
+    playLevelMusic: vi.fn(),
+    playLevelWinSound: vi.fn(),
+    stopLevelMusic: vi.fn(),
+  },
+  activateAudio: vi.fn(),
+}));
+vi.mock('../src/components/game/staticSandLayer', () => ({
+  createStaticSandLayer: () => document.createElement('canvas'),
+}));
+
+import { GameEngine } from '../src/components/game/GameEngine';
+
+function createEngine() {
+  const canvas = document.createElement('canvas');
+  const ctx = { imageSmoothingEnabled: false } as unknown as CanvasRenderingContext2D;
+  const engine = new GameEngine(canvas, ctx, {
+    onGameEnd: () => {},
+    onStateUpdate: () => {},
+    initialState: {},
+  });
+  return engine;
+}
+
+describe('boss coin spawning', () => {
+  it('spawnBossCoinsOnHit pushes given number of coins', () => {
+    const engine = createEngine();
+    const boss = { x: 50, y: 50, width: 40, height: 40 };
+    engine.spawnBossCoinsOnHit(5, boss);
+    expect((engine as any).coins.length).toBe(5);
+    expect((engine as any).coins.every((c: any) => c._bossCoin)).toBe(true);
+  });
+
+  it('spawnBossCoins uses internal boss', () => {
+    const engine = createEngine();
+    (engine as any).bossLucia = { x: 10, y: 10, width: 30, height: 30, health: 100, image: new Image(), direction: 1 };
+    engine.spawnBossCoins(3);
+    expect((engine as any).coins.length).toBe(3);
+    expect((engine as any).coins.every((c: any) => c._bossCoin)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add `spawnBossCoins` and `spawnBossCoinsOnHit` methods to `GameEngine`
- expose ability for `bullets.ts` to spawn boss coins
- test boss coin spawning behaviour

## Testing
- `npm test` *(fails: Dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685a63d76f1c832c9c12ef36c50ce6d9