### PR TITLE
Add getters for particle system and screen shake

### DIFF
--- a/src/components/game/GameEngine.ts
+++ b/src/components/game/GameEngine.ts
@@ -375,6 +375,14 @@ export class GameEngine {
     return audioManager.isMutedState();
   }
 
+  public getParticleSystem(): ParticleSystem {
+    return this.particleSystem;
+  }
+
+  public getScreenShake(): ScreenShake {
+    return this.screenShake;
+  }
+
   private tick = () => {
     gameTick(this);
     this.animationId = requestAnimationFrame(this.tick);

--- a/src/components/game/renderer.ts
+++ b/src/components/game/renderer.ts
@@ -10,7 +10,7 @@ export function renderScene(
   engine: any // GameEngine instance
 ) {
   // Apply screen shake at the beginning
-  engine.screenShake.applyShake(ctx);
+  engine.getScreenShake().applyShake(ctx);
 
   // Ensure alpha is reset before drawing
   ctx.globalAlpha = 1;
@@ -251,10 +251,10 @@ export function renderScene(
   }
 
   // Render particle effects on top of everything else
-  engine.particleSystem.render(ctx);
+  engine.getParticleSystem().render(ctx);
 
   // Reset screen shake at the end
-  engine.screenShake.resetShake(ctx);
+  engine.getScreenShake().resetShake(ctx);
 
   // Restore default alpha in case effects changed it
   ctx.globalAlpha = 1;

--- a/tests/gameengine-getters.test.ts
+++ b/tests/gameengine-getters.test.ts
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+import { it, expect, vi } from 'vitest';
+
+vi.mock('../src/components/game/audioManager', () => ({
+  audioManager: {
+    toggleMute: vi.fn(),
+    isMutedState: vi.fn().mockReturnValue(false),
+    playLevelMusic: vi.fn(),
+    playLevelWinSound: vi.fn(),
+    stopLevelMusic: vi.fn(),
+  },
+  activateAudio: vi.fn(),
+}));
+
+vi.mock('../src/components/game/staticSandLayer', () => ({
+  createStaticSandLayer: () => document.createElement('canvas'),
+}));
+
+import { GameEngine } from '../src/components/game/GameEngine';
+import { ParticleSystem } from '../src/components/game/particleSystem';
+import { ScreenShake } from '../src/components/game/screenShake';
+
+it('provides particle system and screen shake via getters', () => {
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d')!;
+  const engine = new GameEngine(canvas, ctx, {
+    onGameEnd: () => {},
+    onStateUpdate: () => {},
+    initialState: {},
+  });
+
+  expect(engine.getParticleSystem()).toBeInstanceOf(ParticleSystem);
+  expect(engine.getScreenShake()).toBeInstanceOf(ScreenShake);
+});


### PR DESCRIPTION
## Summary
- expose `particleSystem` and `screenShake` via `getParticleSystem()` and `getScreenShake()`
- update the renderer to use the new getters
- add tests verifying these getters return the correct instances

## Testing
- `npm test` *(fails: Dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685a63ddd864832cb996abf93e5f70fd