### PR TITLE
Add themed parallax layers

### DIFF
--- a/src/components/game/GameEngine.ts
+++ b/src/components/game/GameEngine.ts
@@ -226,6 +226,10 @@ export class GameEngine {
 
     const cfg = getLevelConfig(this.player.level);
 
+    loadParallaxLayers(cfg.background).then((layers) => {
+      this.parallaxLayers = layers;
+    });
+
     this.enemies = [];
     this.swordfish = [];
     this.coins = [];
@@ -458,9 +462,10 @@ export class GameEngine {
       swordfishLeft: new Image(),
     };
 
+    const initialConfig = getLevelConfig(this.player.level);
     this.loadPromise = Promise.all([
       loadImages(this.images),
-      loadParallaxLayers().then((layers) => {
+      loadParallaxLayers(initialConfig.background).then((layers) => {
         this.parallaxLayers = layers;
       }),
     ]).then(() => {});

--- a/src/components/game/levels/index.ts
+++ b/src/components/game/levels/index.ts
@@ -29,6 +29,7 @@ const bossLevelConfig: LevelConfig = {
   wineCount: 2,
   swordfishCount: 0,
   boss: true,
+  background: 'jungle',
 };
 
 export function getLevelConfig(level: number): LevelConfig {

--- a/src/components/game/levels/level1.ts
+++ b/src/components/game/levels/level1.ts
@@ -7,6 +7,7 @@ export const level1Config: LevelConfig = {
   brasilenaCount: 2,
   wineCount: 2,
   swordfishCount: 0,
+  background: 'underwater',
 };
 
 export default level1Config;

--- a/src/components/game/levels/level2.ts
+++ b/src/components/game/levels/level2.ts
@@ -7,6 +7,7 @@ export const level2Config: LevelConfig = {
   brasilenaCount: 2,
   wineCount: 2,
   swordfishCount: 1,
+  background: 'underwater',
 };
 
 export default level2Config;

--- a/src/components/game/levels/level3.ts
+++ b/src/components/game/levels/level3.ts
@@ -7,6 +7,7 @@ export const level3Config: LevelConfig = {
   brasilenaCount: 2,
   wineCount: 2,
   swordfishCount: 2,
+  background: 'underwater',
 };
 
 export default level3Config;

--- a/src/components/game/levels/level4.ts
+++ b/src/components/game/levels/level4.ts
@@ -7,6 +7,7 @@ export const level4Config: LevelConfig = {
   brasilenaCount: 2,
   wineCount: 2,
   swordfishCount: 2,
+  background: 'underwater',
 };
 
 export default level4Config;

--- a/src/components/game/levels/level5.ts
+++ b/src/components/game/levels/level5.ts
@@ -7,6 +7,7 @@ export const level5Config: LevelConfig = {
   brasilenaCount: 2,
   wineCount: 2,
   swordfishCount: 2,
+  background: 'jungle',
 };
 
 export default level5Config;

--- a/src/components/game/levels/level6.ts
+++ b/src/components/game/levels/level6.ts
@@ -7,6 +7,7 @@ export const level6Config: LevelConfig = {
   brasilenaCount: 2,
   wineCount: 2,
   swordfishCount: 3,
+  background: 'jungle',
 };
 
 export default level6Config;

--- a/src/components/game/levels/level7.ts
+++ b/src/components/game/levels/level7.ts
@@ -7,6 +7,7 @@ export const level7Config: LevelConfig = {
   brasilenaCount: 2,
   wineCount: 2,
   swordfishCount: 3,
+  background: 'jungle',
 };
 
 export default level7Config;

--- a/src/components/game/levels/level8.ts
+++ b/src/components/game/levels/level8.ts
@@ -7,6 +7,7 @@ export const level8Config: LevelConfig = {
   brasilenaCount: 2,
   wineCount: 2,
   swordfishCount: 3,
+  background: 'jungle',
 };
 
 export default level8Config;

--- a/src/components/game/levels/level9.ts
+++ b/src/components/game/levels/level9.ts
@@ -7,6 +7,7 @@ export const level9Config: LevelConfig = {
   brasilenaCount: 2,
   wineCount: 2,
   swordfishCount: 4,
+  background: 'jungle',
 };
 
 export default level9Config;

--- a/src/components/game/types.ts
+++ b/src/components/game/types.ts
@@ -23,4 +23,5 @@ export interface LevelConfig {
   wineCount: number;
   swordfishCount?: number;
   boss?: boolean;
+  background?: string;
 }

--- a/tests/level-config.test.ts
+++ b/tests/level-config.test.ts
@@ -6,6 +6,7 @@ describe('level configuration lookup', () => {
     const cfg = getLevelConfig(1);
     expect(cfg.enemyCount).toBe(4);
     expect(cfg.coinCount).toBe(7);
+    expect(cfg.background).toBe('underwater');
   });
 
   it('returns level1 config for unknown or negative levels', () => {
@@ -25,5 +26,9 @@ describe('level configuration lookup', () => {
     expect(getLevelConfig(10).boss).toBe(true);
     expect(getLevelConfig(15).boss).toBe(true);
     expect(getLevelConfig(999).boss).toBe(true);
+  });
+
+  it('includes correct background theme', () => {
+    expect(getLevelConfig(5).background).toBe('jungle');
   });
 });

--- a/tests/parallaxLayers.test.ts
+++ b/tests/parallaxLayers.test.ts
@@ -3,12 +3,19 @@ import { describe, it, expect } from 'vitest'
 import { loadParallaxLayers } from '../src/components/game/parallaxLayers'
 
 describe('loadParallaxLayers', () => {
-  it('provides image objects for all layers', async () => {
+  it('provides image objects for default theme', async () => {
     const layers = await loadParallaxLayers()
     expect(layers.far).toBeDefined()
     expect(layers.mid).toBeDefined()
     expect(layers.near).toBeDefined()
     expect(typeof layers.far.src).toBe('string')
     expect(layers.far.src.length).toBeGreaterThan(0)
+  })
+
+  it('loads a different theme when requested', async () => {
+    const jungle = await loadParallaxLayers('jungle')
+    expect(jungle.far).toBeDefined()
+    expect(jungle.mid).toBeDefined()
+    expect(jungle.near).toBeDefined()
   })
 })


### PR DESCRIPTION
## Summary
- support optional background theme per level
- generate unique parallax layer sets and cache them by theme
- load the correct parallax set when generating each level
- test background themes and parallax loader

## Testing
- `npm test` *(fails: Dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685a6e499c9c832c90d589f0c53f324d