### PR TITLE
Add parallax initialization helper

### DIFF
--- a/src/components/game/GameEngine.ts
+++ b/src/components/game/GameEngine.ts
@@ -13,10 +13,10 @@ import { generateBubbles, updateBubbles, drawBubbles } from './bubblesManager';
 import { createDefaultPlatforms } from './platformsManager';
 import { setupKeyboardHandlers } from './controlsManager';
 
-import { renderScene } from './renderer';
+import { renderScene, initParallax, getParallaxLayers } from './renderer';
 import { gameTick } from './loop';
 import { loadImages } from './imageLoader';
-import { loadParallaxLayers, ParallaxLayers } from './parallaxLayers';
+import { ParallaxLayers } from './parallaxLayers';
 
 import { spawnResourceForType, ResourceType } from './resourceSpawner';
 import { spawnDynamicPlatform, updateDynamicPlatforms } from './dynamicPlatforms';
@@ -460,8 +460,8 @@ export class GameEngine {
 
     this.loadPromise = Promise.all([
       loadImages(this.images),
-      loadParallaxLayers().then((layers) => {
-        this.parallaxLayers = layers;
+      initParallax().then(() => {
+        this.parallaxLayers = getParallaxLayers();
       }),
     ]).then(() => {});
     setupKeyboardHandlers(this.keys, this.shoot.bind(this));

--- a/src/components/game/parallaxLayers.ts
+++ b/src/components/game/parallaxLayers.ts
@@ -4,8 +4,10 @@ export interface ParallaxLayers {
   near: HTMLImageElement
 }
 
-let cachedLayers: ParallaxLayers | null = null
-let cachedPromise: Promise<ParallaxLayers> | null = null
+export type ParallaxTheme = string
+
+const cachedLayers: Record<string, ParallaxLayers> = {}
+const cachedPromises: Record<string, Promise<ParallaxLayers>> = {}
 
 function canvasToImage(canvas: HTMLCanvasElement): HTMLImageElement {
   const img = new Image()
@@ -103,11 +105,11 @@ function drawNearLayer(): HTMLCanvasElement {
   return ctx.canvas
 }
 
-export function loadParallaxLayers(): Promise<ParallaxLayers> {
-  if (cachedLayers) return Promise.resolve(cachedLayers)
-  if (cachedPromise) return cachedPromise
+export function loadParallaxLayers(theme: ParallaxTheme = 'default'): Promise<ParallaxLayers> {
+  if (cachedLayers[theme]) return Promise.resolve(cachedLayers[theme])
+  if (cachedPromises[theme]) return cachedPromises[theme]
 
-  cachedPromise = new Promise((resolve) => {
+  cachedPromises[theme] = new Promise((resolve) => {
     const farCanvas = drawFarLayer()
     const midCanvas = drawMidLayer()
     const nearCanvas = drawNearLayer()
@@ -121,8 +123,8 @@ export function loadParallaxLayers(): Promise<ParallaxLayers> {
     const check = () => {
       loaded += 1
       if (loaded === images.length) {
-        cachedLayers = { far: farImg, mid: midImg, near: nearImg }
-        resolve(cachedLayers)
+        cachedLayers[theme] = { far: farImg, mid: midImg, near: nearImg }
+        resolve(cachedLayers[theme])
       }
     }
 
@@ -136,5 +138,5 @@ export function loadParallaxLayers(): Promise<ParallaxLayers> {
     })
   })
 
-  return cachedPromise
+  return cachedPromises[theme]
 }

--- a/src/components/game/renderer.ts
+++ b/src/components/game/renderer.ts
@@ -1,5 +1,17 @@
 import { drawPixelCoral } from './drawPixelCoral';
 import { drawPixelSand } from './drawPixelSand';
+import { loadParallaxLayers, ParallaxLayers, ParallaxTheme } from './parallaxLayers';
+
+let parallaxLayers: ParallaxLayers | null = null;
+
+export async function initParallax(theme: ParallaxTheme = 'default') {
+  parallaxLayers = await loadParallaxLayers(theme);
+  return parallaxLayers;
+}
+
+export function getParallaxLayers() {
+  return parallaxLayers;
+}
 
 function isImageLoaded(img?: HTMLImageElement): img is HTMLImageElement {
   return !!img && img.complete && img.naturalWidth > 0;
@@ -34,7 +46,7 @@ export function renderScene(
   ctx.fillRect(0, 0, canvas.width, canvas.height);
 
   // Draw scrolling parallax background on top of the gradient
-  const layers = engine.parallaxLayers;
+  const layers = getParallaxLayers();
   if (layers && isImageLoaded(layers.far)) {
     ctx.drawImage(layers.far, 0, 0);
     ctx.drawImage(layers.mid, 0, 0);


### PR DESCRIPTION
## Summary
- cache parallax layers by theme
- add `initParallax` and `getParallaxLayers` helpers in the renderer
- load parallax layers through the renderer when creating the `GameEngine`

## Testing
- `npx vitest run` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_685a6e4b46a4832cb8231478e6c72edd