### PR TITLE
Add image cache to loader

### DIFF
--- a/src/components/game/imageLoader.ts
+++ b/src/components/game/imageLoader.ts
@@ -12,19 +12,67 @@ export interface GameImages {
   swordfishLeft: HTMLImageElement
 }
 
+const cache = new Map<string, HTMLImageElement>()
+
+function getCachedImage(url: string, provided: HTMLImageElement): HTMLImageElement {
+  const cached = cache.get(url)
+  if (cached) {
+    return cached
+  }
+  provided.src = url
+  cache.set(url, provided)
+  return provided
+}
+
 export function loadImages(images: GameImages): Promise<void> {
-  images.playerFrames[0].src = "/uploads/080fcc27-fe7b-448a-9661-9e1a894abab7.png"
-  images.playerFrames[1].src = "/uploads/1c2ed28f-2e83-4dbd-8327-8c1f2c00c060.png"
-  images.playerLeft.src = "/uploads/2d15af34-fad3-4789-80a2-b0f9d9a204a0.png"
-  images.enemy.src = "/uploads/63f3c1bb-af9c-4c63-86ae-a15bc687d8a8.png"
-  images.enemyLeft.src = "/uploads/64235a5a-8a4e-4fac-83fe-14e82ff1bba0.png"
-  images.pizza.src = "/uploads/65338906-ef6b-4097-bcbc-73770f962827.png"
-  images.brasilena.src = "/uploads/8cb50a4f-d767-4a5d-bdf6-751db3255aec.png"
-  images.wine.src = "/uploads/989f5507-8b03-451b-b9c1-b0e2d1cc1aaa.png"
-  images.coin.src = "/uploads/a8dae000-616d-4f8b-bce1-d8b37c9eae56.png"
-  images.bossLucia.src = "/uploads/Boss%20sprite%20lucia.png"
-  images.swordfishRight.src = "/uploads/swordfish-right.png"
-  images.swordfishLeft.src = "/uploads/swordfish-left.png"
+  images.playerFrames[0] = getCachedImage(
+    "/uploads/080fcc27-fe7b-448a-9661-9e1a894abab7.png",
+    images.playerFrames[0]
+  )
+  images.playerFrames[1] = getCachedImage(
+    "/uploads/1c2ed28f-2e83-4dbd-8327-8c1f2c00c060.png",
+    images.playerFrames[1]
+  )
+  images.playerLeft = getCachedImage(
+    "/uploads/2d15af34-fad3-4789-80a2-b0f9d9a204a0.png",
+    images.playerLeft
+  )
+  images.enemy = getCachedImage(
+    "/uploads/63f3c1bb-af9c-4c63-86ae-a15bc687d8a8.png",
+    images.enemy
+  )
+  images.enemyLeft = getCachedImage(
+    "/uploads/64235a5a-8a4e-4fac-83fe-14e82ff1bba0.png",
+    images.enemyLeft
+  )
+  images.pizza = getCachedImage(
+    "/uploads/65338906-ef6b-4097-bcbc-73770f962827.png",
+    images.pizza
+  )
+  images.brasilena = getCachedImage(
+    "/uploads/8cb50a4f-d767-4a5d-bdf6-751db3255aec.png",
+    images.brasilena
+  )
+  images.wine = getCachedImage(
+    "/uploads/989f5507-8b03-451b-b9c1-b0e2d1cc1aaa.png",
+    images.wine
+  )
+  images.coin = getCachedImage(
+    "/uploads/a8dae000-616d-4f8b-bce1-d8b37c9eae56.png",
+    images.coin
+  )
+  images.bossLucia = getCachedImage(
+    "/uploads/Boss%20sprite%20lucia.png",
+    images.bossLucia
+  )
+  images.swordfishRight = getCachedImage(
+    "/uploads/swordfish-right.png",
+    images.swordfishRight
+  )
+  images.swordfishLeft = getCachedImage(
+    "/uploads/swordfish-left.png",
+    images.swordfishLeft
+  )
 
   const list: HTMLImageElement[] = [
     images.playerFrames[0],

--- a/tests/image-loader.test.ts
+++ b/tests/image-loader.test.ts
@@ -43,4 +43,70 @@ describe('loadImages', () => {
 
     await expect(promise).resolves.toBeUndefined()
   })
+
+  it('reuses cached images on subsequent calls', async () => {
+    const first = {
+      playerFrames: [createImg(), createImg()],
+      playerLeft: createImg(),
+      enemy: createImg(),
+      enemyLeft: createImg(),
+      pizza: createImg(),
+      brasilena: createImg(),
+      wine: createImg(),
+      coin: createImg(),
+      bossLucia: createImg(),
+      swordfishRight: createImg(),
+      swordfishLeft: createImg(),
+    }
+
+    const p1 = loadImages(first as any)
+    ;[
+      ...first.playerFrames,
+      first.playerLeft,
+      first.enemy,
+      first.enemyLeft,
+      first.pizza,
+      first.brasilena,
+      first.wine,
+      first.coin,
+      first.bossLucia,
+      first.swordfishRight,
+      first.swordfishLeft,
+    ].forEach((img) => {
+      img.complete = true
+      img.onload && img.onload()
+    })
+    await expect(p1).resolves.toBeUndefined()
+
+    const second = {
+      playerFrames: [createImg(), createImg()],
+      playerLeft: createImg(),
+      enemy: createImg(),
+      enemyLeft: createImg(),
+      pizza: createImg(),
+      brasilena: createImg(),
+      wine: createImg(),
+      coin: createImg(),
+      bossLucia: createImg(),
+      swordfishRight: createImg(),
+      swordfishLeft: createImg(),
+    }
+
+    const p2 = loadImages(second as any)
+
+    expect(second.playerFrames[0]).toBe(first.playerFrames[0])
+    expect(second.playerFrames[1]).toBe(first.playerFrames[1])
+    expect(second.playerLeft).toBe(first.playerLeft)
+    expect(second.enemy).toBe(first.enemy)
+    expect(second.enemyLeft).toBe(first.enemyLeft)
+    expect(second.pizza).toBe(first.pizza)
+    expect(second.brasilena).toBe(first.brasilena)
+    expect(second.wine).toBe(first.wine)
+    expect(second.coin).toBe(first.coin)
+    expect(second.bossLucia).toBe(first.bossLucia)
+    expect(second.swordfishRight).toBe(first.swordfishRight)
+    expect(second.swordfishLeft).toBe(first.swordfishLeft)
+
+    await expect(p2).resolves.toBeUndefined()
+  })
 })


### PR DESCRIPTION
## Summary
- cache HTMLImageElements in `imageLoader.ts`
- reuse cached images when loading again
- test that cached images are returned on subsequent loads

## Testing
- `npm test --silent` *(fails: Dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685a7a3c7a30832c97164cce6f3eb610